### PR TITLE
Add task try number to ecf log file name

### DIFF
--- a/parm/setup_wflow_env.py
+++ b/parm/setup_wflow_env.py
@@ -649,7 +649,7 @@ def create_jobcard_envvar(home_dir,parm_dir,config_parm,config_parm_str):
         nprocs_per_node_task = f'''nprocs_per_node_{itask}'''
         walltime_task = f'''walltime_{itask}'''
         if workflow_manager == "ecflow":
-            output_fn = f'''{itask}_%ECF_DATE%%CYC%.log'''
+            output_fn = f'''{itask}_%ECF_DATE%%CYC%_%ECF_TRYNO%.log'''
         else:
             output_fn = f'''{itask}_{date_first_cycle}.log'''
         output_name = os.path.join(log_dir_path,output_fn)


### PR DESCRIPTION
## Description:
<!--
Provide a detailed description of what this PR does. 
What bug does it fix?
What feature does it add?
-->
- Add a task try number to the ecflow log file name.


## Linked Issues:
<!--
Please link the related issues to be closed with this PR
EXAMPLE: Closes ufs-community/ufs-da-workflow/issues/<issue_number>
-->
- Issue #8

## Test Conducted on Following Platforms (Machines):
- RDHPCS
    - [x] Ursa
    - [ ] Hercules
    - [ ] Orion
    - [ ] Gaea-c6
    - [ ] Derecho
- PW-Clouds
    - [ ] AWS
    - [ ] AZURE
    - [ ] GCP
