### PR TITLE
Add LND coupling option to build script

### DIFF
--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -51,10 +51,14 @@ list(APPEND UFS_MODEL_ARGS
   "-DCCPP_SUITES=${CCPP_SUITES}"
   "-DMPI=ON"
 )
-if( NOT APP STREQUAL "S2SWAL" )
+if( APP MATCHES "S2SWA" )
   list(APPEND UFS_MODEL_ARGS
     "-D32BIT=ON"
     "-DPDLIB=ON"
+  )
+elseif( APP MATCHES "ATML" OR APP MATCHES "ATM" )
+  list(APPEND UFS_MODEL_ARGS
+    "-D32BIT=ON"
   )
 endif()
 if( NOT DA_UTILS_ONLY )
@@ -115,7 +119,7 @@ else()
   "-DWEIGHT_GEN=OFF"
   )
 endif()
-if( NOT DA_UTILS_ONLY )
+if( NOT DA_UTILS_ONLY AND NOT APP STREQUAL "LND" )
   if( APP MATCHES "ATML" )
     list(APPEND TARGET LIST UFS_UTILS_nofrac.fd)
     ExternalProject_Add(UFS_UTILS_nofrac.fd

--- a/sorc/app_build.sh
+++ b/sorc/app_build.sh
@@ -17,8 +17,8 @@ OPTIONS
       compiler to use; default depends on platform
       (e.g. intel | gnu | cray | gccgfortran)
   -a, --app=APPLICATION
-      weather model application to build; for example, S2SWA for GFS
-      (e.g. S2SWA | S2SWAL | NG-GODAS | ATML | ATM )
+      weather model application to build; for example, S2SWA for GFS/GEFS
+      (e.g. S2SWA | S2SWAL | NG-GODAS | ATML | ATM | LND)
   --ccpp="CCPP_SUITE1,CCPP_SUITE2..."
       CCPP suites (CCPP_SUITES) to include in build; delimited with ','
   --remove


### PR DESCRIPTION
## Description:
<!--
Provide a detailed description of what this PR does. 
What bug does it fix?
What feature does it add?
-->
- Add the `LND` coupling option of the ufs weather model to the app build script.


## Linked Issues:
<!--
Please link the related issues to be closed with this PR
EXAMPLE: Closes ufs-community/ufs-da-workflow/issues/<issue_number>
-->
- Resolve Issue #38 

## Test Conducted on Following Platforms (Machines):
- RDHPCS
    - [x] Ursa
    - [ ] Hercules
    - [ ] Orion
    - [ ] Gaea-c6
    - [ ] Derecho
- PW-Clouds
    - [ ] AWS
    - [ ] AZURE
    - [ ] GCP
